### PR TITLE
chore(add type): use getFileInfo Return type

### DIFF
--- a/src/__tests__/fileCollectionItemsUngzip.test.ts
+++ b/src/__tests__/fileCollectionItemsUngzip.test.ts
@@ -36,7 +36,7 @@ describe('fileCollectionItemsUngzip', () => {
       ]
     `);
 
-    if (parseInt(process.versions.node) >= 18) {
+    if (Number.parseInt(process.versions.node, 10) >= 18) {
       const stream = fileCollectionUngzipped[1].stream();
       const results = [];
       //@ts-expect-error feature is too new

--- a/src/groupFiles.ts
+++ b/src/groupFiles.ts
@@ -7,7 +7,10 @@ type GroupByOption =
   | 'baseDir'
   | 'extension'
   | 'filename'
-  | ((file?: FileCollectionItem, fileInfo?: StringObject) => string);
+  | ((
+      file?: FileCollectionItem,
+      fileInfo?: ReturnType<typeof getFileInfo>,
+    ) => string);
 
 interface GroupOfFileCollection {
   meta: StringObject;


### PR DESCRIPTION
**Changes**

* `groupBy` callback uses getFileInfo return type 
* eslint warning for `radix`.

**Question**

Maybe the test should also be extended or changed from just passing `files` to something like this? 

```typescript
    const groupedFilesUsingInfo = groupFiles(files, {
      groupBy: (file, info?) => {
        if (info) {
          return info.extension.substring(0, 2);
        }
      },
    } as GroupFilesOptions);
    expect(groupedFilesUsingInfo).toHaveLength(2);
    expect(groupedFilesUsingInfo.map((result) => result.key)).toStrictEqual([ 'Mp', 'mp']);
```