### PR TITLE
fix: support relative path starting with "./"

### DIFF
--- a/src/utilities/__tests__/shouldAddItem.test.ts
+++ b/src/utilities/__tests__/shouldAddItem.test.ts
@@ -6,4 +6,6 @@ test('shouldAddItem', async () => {
   expect(shouldAddItem('.dotFolder/a.txt')).toBe(false);
   expect(shouldAddItem('dir1/a.txt')).toBe(true);
   expect(shouldAddItem('dir1/.b.txt')).toBe(false);
+  expect(shouldAddItem('./test.txt')).toBe(true);
+  expect(shouldAddItem('./.test.txt')).toBe(false);
 });

--- a/src/utilities/shouldAddItem.ts
+++ b/src/utilities/shouldAddItem.ts
@@ -2,7 +2,7 @@ import { FilterOptions } from '../Options';
 
 /**
  * Utility function that allows to filter files from a FileCollection ignore by default the dotFiles
- * @param fileCollection
+ * @param relativePath
  * @param options
  * @returns
  */
@@ -13,8 +13,9 @@ export function shouldAddItem(
   const { ignoreDotfiles = true } = options;
   if (ignoreDotfiles) {
     return (
-      relativePath.split('/').filter((part) => part.startsWith('.')).length ===
-      0
+      relativePath
+        .split('/')
+        .filter((part) => part.startsWith('.') && part !== '.').length === 0
     );
   }
   return true;


### PR DESCRIPTION
This can happen with recent versions of `react-dropzone`.

Refs: https://github.com/react-dropzone/file-selector/commit/0dff2f94eedbc1a140d0efa0aede17c7819a35c2
